### PR TITLE
GPII-17: Update mobile a11y prefs

### DIFF
--- a/gpii/node_modules/gpii-oauth2/gpii-oauth2-authz-server/public/src/core/available-authorized-preferences/es.codefactory.android.app.ma.json
+++ b/gpii/node_modules/gpii-oauth2/gpii-oauth2-authz-server/public/src/core/available-authorized-preferences/es.codefactory.android.app.ma.json
@@ -4,5 +4,6 @@
     "visual-alternatives.speak-text.rate": true,
     "visual-alternatives.speak-text.pitch": true,
     "visual-alternatives.speak-text.announce": true,
-    "visual-alternatives.speak-text.read-back": true
+    "visual-alternatives.speak-text.read-back": true,
+    "visual-alternatives.braille": true
 }

--- a/testData/ontologies/privacy-flat.json
+++ b/testData/ontologies/privacy-flat.json
@@ -30,6 +30,7 @@
     "http://registry\\.gpii\\.net/provisional-common/fontName": "visual-styling.text-style",
 
     "http://registry\\.gpii\\.net/common/brailleMode": "visual-alternatives.braille.enable",
+    "http://registry\\.gpii\\.net/common/screenReaderBrailleOutput": "visual-alternatives.braille.screen-reader-braille-output",
     "http://registry\\.gpii\\.net/common/signLanguageEnabled": "textual-alternatives.sign-language.enable",
 
     "http://registry\\.gpii\\.net/common/invertColours": "visual-styling.change-contrast.invert-colours",


### PR DESCRIPTION
Updated the prefs for the mobile a11y service. The available authorized prefs now contains braille, and the privacy-flat.json ontology maps screen reader braille output.